### PR TITLE
🐛 Fix var spacing in template

### DIFF
--- a/d3b_cli_igor/deploy_ops/generate_config.py
+++ b/d3b_cli_igor/deploy_ops/generate_config.py
@@ -50,11 +50,14 @@ def generate(account_name, organization, region, environment, config_file, mode)
     for line in lines:
         if "project_name" in line or "projectName" in line:
             name, var = line.partition("=")[::2]
+            f.write("\n")
             f.write("export TF_VAR_" + name.strip() + "=" + var.strip() + "")
+            f.write("\n")
         if (environment+"_cidr") in line:
             name, var = line.partition("=")[::2]
             f.write("\n")
             f.write("export TF_VAR_chop_cidr=\"[" + var.strip().replace("\"", "\\\"") + "]\"")
+            f.write("\n")
     f.write(
         """
     S3_SECRETS_BUCKET_PREFIX="${TF_VAR_organization}-${TF_VAR_account_id}-${region}-${TF_VAR_environment}-secrets/${TF_VAR_projectName}"


### PR DESCRIPTION
https://github.com/include-dcc/include-users-api was not deploying to prd in [this job](https://aws-infra-jenkins-service.373997854230.d3b.io/job/include-dcc-include-users-api-at-app.deploy/job/v1.7/3/console). The cause was the template in the variables.tfvar file being generated that didn't have a new line in between the `chop_cidr` variable and the `vpc_prefix` var. Output file looked like this:

```
chop_cidr=["0.0.0.0/0"]export
vpc_prefix="apps"
```

Fixed by adding newline in the template generation code and tested by deploying include-users-api v1.7 to prd from local machine.