### PR TITLE
Remove bad trap SIGINT

### DIFF
--- a/d3b_cli_igor/utils/scripts/dev-env-tunnel
+++ b/d3b_cli_igor/utils/scripts/dev-env-tunnel
@@ -1,7 +1,7 @@
 set -e
-trap ctrl_c SIGINT SIGTERM ERR EXIT INT
+trap ctrl_c SIGTERM ERR EXIT INT
 ctrl_c () {
-    trap - SIGINT SIGTERM ERR EXIT INT
+    trap - SIGTERM ERR EXIT INT
     echo ""
     echo "Exiting tunnel..."
     kill $(ps -ef | grep "ssm start-session" | grep -v grep | awk '{ print $2 }')


### PR DESCRIPTION
When running on my WSL desktop, getting the below error when using the `dev-env-tunnel`. This isn't necessary to have since `INT` is also included in the trap.

```
trap: SIGINT: bad trap
```