### PR TITLE
🚸 Link to aws account notion page

### DIFF
--- a/d3b_cli_igor/utils/config/shortcuts.yaml
+++ b/d3b_cli_igor/utils/config/shortcuts.yaml
@@ -17,3 +17,6 @@ github-d3bcenter:
 github-kidsfirst:
         name: "https://github.com/kids-first"
         description: "KidsFirst Github Account"
+aws-accounts:
+        name: "https://www.notion.so/d3b/AWS-Environments-ddc99e01cad746ff8ed03705e058a140"
+        description: "AWS Accounts Information Notion Page"

--- a/d3b_cli_igor/utils/scripts/awslogin
+++ b/d3b_cli_igor/utils/scripts/awslogin
@@ -15,6 +15,8 @@ if [ ! -z $1 ]; then
 	saml-login -c $1 aws-assume-role
    fi
 else
+ echo "Information about each login can be found here:"
+ echo "    igor shortcuts --name aws-accounts"
  echo "Available logins:"
  count=1
  while IFS= read -r line; do


### PR DESCRIPTION
two additions:

1. Add a shortcut to link to the [aws environments notion page](https://www.notion.so/d3b/AWS-Environments-ddc99e01cad746ff8ed03705e058a140): 

```sh
igor shortcuts --name aws-accounts
```

2. add instructions to reference this shortcut when users invoke `igor awslogin` so that they can reference this notion page to choose the correct account. 