### PR TITLE
⬆️ Update in dev-env-tunnel

### DIFF
--- a/d3b_cli_igor/deploy_ops/config/account_info.json
+++ b/d3b_cli_igor/deploy_ops/config/account_info.json
@@ -32,6 +32,20 @@
        "subnet_prefix"         : "apps",
        "azs"                   : "[\"a\",\"b\"]"
     },
+   "ml-research":
+   {
+       "state_files_bucket"    : "-remote-state-files",
+       "institution_naming_convention": "aws-research-7225140000-d3b-ml-research01-dev",
+       "account_id"	       : "381376188863",
+       "organization"          : "d3b",
+       "dev_cidr"              : "[\"172.22.32.192/26\"]",
+       "instance_type"         : "db.t2.small",
+       "domain_external"       : "aws-research-7225140000-d3b-ml-research01-dev.aws.cloud.chop.edu",
+       "domain_internal"       : "aws-research-7225140000-d3b-ml-research01-dev.aws.cloud.chop.edu",
+       "vpc_prefix"            : "apps",
+       "subnet_prefix"         : "apps",
+       "azs"                   : "[\"a\",\"b\"]"
+    },
    "sandbox":
    {
        "state_files_bucket"    : "sandbox-remote-state-files",

--- a/d3b_cli_igor/deploy_ops/deploy.py
+++ b/d3b_cli_igor/deploy_ops/deploy.py
@@ -11,6 +11,11 @@ logger = d3b_cli_igor.common.get_logger(
 )
 
 def execute_deploy(account_name, organization, region, environment, config_file, mode, debug=False):
+    if (mode == "generate"):
+        d3b_cli_igor.deploy_ops.generate_config.generate(
+            account_name, organization, region, environment, config_file, mode
+        )
+        sys.exit(1)
     d3b_cli_igor.deploy_ops.generate_config.generate(
         account_name, organization, region, environment, config_file, mode
     )

--- a/d3b_cli_igor/deploy_ops/templates/deploy.tmpl
+++ b/d3b_cli_igor/deploy_ops/templates/deploy.tmpl
@@ -33,7 +33,7 @@ mkdir -p .tmp_deployment/.standard
 rsync -av --progress $TF_VAR_branch/* .tmp_deployment/.standard/ --exclude tests 
 rsync -av --progress $TF_VAR_branch/.config .tmp_deployment/.standard/ --exclude tests 
 fi
-git clone --depth=1 -b master git@github.com:d3b-center/aws-infra-deployment.git .tmp_deployment/.deployment
+git clone --depth=1 -b $TF_VAR_deploy_script_version git@github.com:d3b-center/aws-infra-deployment.git .tmp_deployment/.deployment
 cd .tmp_deployment
 #Remove unnecessary files
 rm -rf .standard/tests

--- a/d3b_cli_igor/utils/scripts/dev-env-tunnel
+++ b/d3b_cli_igor/utils/scripts/dev-env-tunnel
@@ -94,8 +94,9 @@ fi
 
 echo "Found instance ${INSTANCE_ID}. Connecting"
 
-echo "ssm-ssh"
-ssm-ssh --region us-east-1 "$INSTANCE_ID" -L $port:"$INSTANCE_IP":22 -fN
+echo "ec2-ssh"
+ec2-ssh --region us-east-1 ssm-user@"$INSTANCE_ID" -L $port:"$INSTANCE_IP":22 -fN
+
 sed '/localhost/d' ~/.ssh/known_hosts >~/.ssh/known_hosts_new
 cp ~/.ssh/known_hosts_new ~/.ssh/known_hosts
 

--- a/igor
+++ b/igor
@@ -58,7 +58,7 @@ def get_logs(app, environment, query, hours):
 @click.option("--region", nargs=1, required=True)
 @click.option("--environment", nargs=1, required=True)
 @click.option("--config_file", nargs=1, default="Jenkinsfile", required=False)
-@click.option("--mode", type=click.Choice(['plan', 'build', 'apply', 'destroy']),  nargs=1, default="apply", required=False)
+@click.option("--mode", type=click.Choice(['plan', 'build', 'apply', 'destroy', 'generate']),  nargs=1, default="apply", required=False)
 @click.option("--debug", is_flag=True, required=False)
 def deploy(account_name, organization, region, environment, config_file, mode, debug):
     check_creds()


### PR DESCRIPTION
Description
------------

Updated dev-env-tunnel to use ec2-ssh instead of ssm-ssh. 

Motivation
-----------

aws-infra-ssm pip package had a new update where it replaced ssm-ssh with 2 commands:
ec2-session and ec2-ssh. The new scripts require to have an additional parameters.
