### PR TITLE
Added a new feature to retrieve secrets without downloading them

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,18 @@ Igor will look for an availble inforamtion about an application. This command wi
 igor get-info --app kf-keycloak --environment qa --account kf-strides
 ~~~
 
+secrets
+-------
+
+Igor will retrieve secrets for a specific application.
+
+***Usage***
+
+~~~
+igor secrets --app kf-keycloak --environment qa --region us-east-1 --account kf-strides
+~~~
+
+
 Developing Igor
 ===============
 

--- a/d3b_cli_igor/app_ops/secrets.py
+++ b/d3b_cli_igor/app_ops/secrets.py
@@ -1,0 +1,29 @@
+import d3b_cli_igor.common
+import boto3
+import boto3, yaml, numpy, sys, time
+from termcolor import colored
+
+logger = d3b_cli_igor.common.get_logger(
+    __name__, testing_mode=False, log_format="detailed"
+)
+
+def pretty_print(output):
+    for item in output:
+        print(colored('Application Name: ','red'),colored(item['app'],'green'))
+        for k in item:
+            print(colored(k,'red'),":",colored(str(item[k]),'green'))
+
+
+def get_secrets(app, environment, account, region):
+    client = boto3.client('s3')
+    account_id = boto3.client('sts').get_caller_identity().get('Account')
+    bucket = account+"-"+account_id+"-"+region+"-"+environment+"-secrets"
+    prefix = app + "/"
+
+    result = client.list_objects_v2(Bucket=bucket, Prefix=prefix, Delimiter="/")
+    for obj in result["Contents"]:
+        print(obj["Key"])
+        print("=============================")
+        s3 = boto3.resource('s3')
+        object_body = s3.Object(bucket,obj["Key"])
+        print(object_body.get()['Body'].read().decode('utf-8'))

--- a/igor
+++ b/igor
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import click
 import time
-import d3b_cli_igor.common, d3b_cli_igor.log_ops.app_logs, d3b_cli_igor.app_ops.ecs_deployment, d3b_cli_igor.deploy_ops.deploy, d3b_cli_igor.deploy_ops.generate_config, d3b_cli_igor.utils.shortcuts, d3b_cli_igor.utils.diff, d3b_cli_igor.app_ops.ecs_get_info
+import d3b_cli_igor.common, d3b_cli_igor.log_ops.app_logs, d3b_cli_igor.app_ops.ecs_deployment, d3b_cli_igor.deploy_ops.deploy, d3b_cli_igor.deploy_ops.generate_config, d3b_cli_igor.utils.shortcuts, d3b_cli_igor.utils.diff, d3b_cli_igor.app_ops.ecs_get_info, d3b_cli_igor.app_ops.secrets
 import boto3
 import boto3
 import sys 
@@ -23,6 +23,21 @@ def check_creds():
 @click.group()
 def igor_cli():
     pass
+
+@click.command(name="secrets")
+@click.option(
+    "--app",
+    nargs=1,
+    required=True,
+    help="Enter Application Name",
+)
+@click.option("--environment", nargs=1, required=True, help="Specify Environment")
+@click.option("--region", default="us-east-1", nargs=1, required=True)
+@click.option("--account", nargs=1, required=True, help="Specify AWS Account")
+def secrets(app, environment, account, region):
+    check_creds()
+    d3b_cli_igor.app_ops.secrets.get_secrets(app, environment, account, region)
+
 
 @click.command(name="get-logs")
 @click.option(
@@ -158,7 +173,6 @@ def get_info(app, environment, account, region):
     check_creds()
     d3b_cli_igor.app_ops.ecs_get_info.get_info(app, environment, account, region)
 
-
 @click.command(name="generate-tf-module-files")
 @click.option('--project',nargs=1,required=True)
 @click.option('--region',nargs=1,required=True)
@@ -171,6 +185,7 @@ def generate_tf_module_files(project,region,account_name,environment,module):
 igor_cli.add_command(get_logs)
 igor_cli.add_command(restart)
 igor_cli.add_command(get_info)
+igor_cli.add_command(secrets)
 igor_cli.add_command(deploy)
 igor_cli.add_command(generate_tf_module_files)
 igor_cli.add_command(shortcuts)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ click
 pyyaml>=5.4
 datetime
 aws-ssm-tools
-auth0-login
+auth0-login<=0.5.2


### PR DESCRIPTION
Motivation
========

The AWS environment currently has secrets in buckets as s3 objects. Unfortunately, this creates an issue with viewing secrets. The current process involves downloading secrets to look through them. 

Description
=========

I created an operation to look at the secret files without downloading them. This operation will stream objects directly into memory, which makes them absolutely ephemeral and more secure. 

