### PR TITLE
🐛 Adding region to common.setup

### DIFF
--- a/d3b_cli_igor/common.py
+++ b/d3b_cli_igor/common.py
@@ -30,8 +30,8 @@ def get_account_info():
         account_information = json.load(json_file)
     return account_information
 
-def setup(client_name=""):
-    client = boto3.client(client_name)
+def setup(client_name="", region="us-east-1"):
+    client = boto3.client(client_name, region_name=region)
     return client
 
 


### PR DESCRIPTION
A [jenkins job](https://aws-infra-jenkins-service.d3b.io/job/d3b-center-aws-infra-d3b-accounts/job/feature%252Fcbl%252FISDEVOPS-760/1/execution/node/50/log/) failed with the below error using igor:
```
    botocore.exceptions.NoRegionError: You must specify a region.
```
This PR will add `us-east-1` as a default region when calling d3b_cli_igor.common.setup()