### PR TITLE
🐛 Fix username bug for dev-env-tunnel

### DIFF
--- a/d3b_cli_igor/utils/scripts/dev-env-tunnel
+++ b/d3b_cli_igor/utils/scripts/dev-env-tunnel
@@ -11,6 +11,7 @@ ctrl_c() {
 
 syslevel=$1
 cidr_blocks=$2
+username=$(whoami)
 
 if [[ ! "$syslevel" =~ ^(dev|qa|prd|service)$ ]]; then
   echo "You specified an unknown environment $1 (should be among: dev | qa | prd | service )."
@@ -95,7 +96,7 @@ fi
 echo "Found instance ${INSTANCE_ID}. Connecting"
 
 echo "ec2-ssh"
-ec2-ssh --region us-east-1 `whoami`@"$INSTANCE_ID" -L $port:"$INSTANCE_IP":22 -fN
+ec2-ssh --region us-east-1 "$username"@"$INSTANCE_ID" -L $port:"$INSTANCE_IP":22 -fN
 
 sed '/localhost/d' ~/.ssh/known_hosts >~/.ssh/known_hosts_new
 cp ~/.ssh/known_hosts_new ~/.ssh/known_hosts


### PR DESCRIPTION
Currently, when running in the chopd3bPrd account, the ssm-user is being used to login to the bastion instances after initial lookup, no matter who is opening the tunnel.

```
Running in AWS account: 684194535433
Opening Connection
getting info
Found instance i-0745968dfe012e78c. Connecting
ec2-ssh
INFO: Resolved instance name 'i-0745968dfe012e78c' to 'i-0745968dfe012e78c'
INFO: Using SSH key from SSH Agent, should be as good as any.
The authenticity of host 'i-0745968dfe012e78c (<no hostip for proxy command>)' can't be established.
ED25519 key fingerprint is SHA256:xzfSGQMR45GnYDkrlDCulT8qGuJXjUrjpuOQrr4nULk.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added 'i-0745968dfe012e78c' (ED25519) to the list of known hosts.
ssm-user@i-0745968dfe012e78c: Permission denied (publickey,gssapi-keyex,gssapi-with-mic).
```